### PR TITLE
Upgrade backend from .NET 6 to .NET 10

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.100
+        dotnet-version: 10.0.x
     - name: Build with dotnet
       run: dotnet build --configuration Release src/FamUnion.sln

--- a/.github/workflows/dotnetcoretest.yml
+++ b/.github/workflows/dotnetcoretest.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.100
+          dotnet-version: 10.0.x
       - name: Test with dotnet
         run: dotnet test -c Release src/FamUnion.sln

--- a/src/FamUnion.Api/Controllers/ReunionsController.cs
+++ b/src/FamUnion.Api/Controllers/ReunionsController.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using RestSharp.Serialization;
 
 namespace FamUnion.Api.Controllers
 {
@@ -104,7 +103,7 @@ namespace FamUnion.Api.Controllers
                 var resp = CreatedAtAction("GetReunion",
                     routeValues: new { id = result.Id.Value },
                     value: result);
-                resp.ContentTypes.Add(ContentType.Json);
+                resp.ContentTypes.Add("application/json");
                 return resp;
             }
             catch (Exception ex)

--- a/src/FamUnion.Api/Dockerfile
+++ b/src/FamUnion.Api/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY ["FamUnion.Api/FamUnion.Api.csproj", "FamUnion.Api/"]
 COPY ["FamUnion.Infrastructure/FamUnion.Infrastructure.csproj", "FamUnion.Infrastructure/"]

--- a/src/FamUnion.Api/FamUnion.Api.csproj
+++ b/src/FamUnion.Api/FamUnion.Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <UserSecretsId>836398e1-deea-4d85-b8ee-7f9e3cb9edf2</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
@@ -15,11 +15,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="5.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.9" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
-	<PackageReference Include="NSwag.AspNetCore" Version="13.11.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.0" />
+	<PackageReference Include="NSwag.AspNetCore" Version="14.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FamUnion.Api/FamUnion.Api.csproj
+++ b/src/FamUnion.Api/FamUnion.Api.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="10.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.0" />

--- a/src/FamUnion.Api/Startup.cs
+++ b/src/FamUnion.Api/Startup.cs
@@ -171,7 +171,7 @@ namespace FamUnion.Api
             {
                 options.DocumentName = "FamUnion API";
             }); // serve OpenAPI/Swagger documents
-            app.UseSwaggerUi3(options =>
+            app.UseSwaggerUi(options =>
             {
                 options.DocumentTitle = "FamUnion API";
             }); // serve Swagger UI

--- a/src/FamUnion.Core.Tests/FamUnion.Core.Tests.csproj
+++ b/src/FamUnion.Core.Tests/FamUnion.Core.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/FamUnion.Core/Auth/TokenHelper.cs
+++ b/src/FamUnion.Core/Auth/TokenHelper.cs
@@ -8,23 +8,18 @@ namespace FamUnion.Core.Auth
     {
         public static Auth0Token GetAuth0Token(AuthConfig authConfig)
         {
-            var client = new RestClient($"https://{authConfig.Domain}/oauth/token");
-            var request = new RestRequest(Method.POST);
-            request.AddHeader("content-type", "application/json");
-            request.AddParameter("application/json",
-                JsonConvert.SerializeObject(
-                    new
-                    {
-                        client_id = authConfig.ClientId,
-                        client_secret = authConfig.ClientSecret,
-                        audience = authConfig.Audience,
-                        grant_type = "client_credentials"
-                    })
-                , ParameterType.RequestBody
-                );
+            var options = new RestClientOptions($"https://{authConfig.Domain}");
+            using var client = new RestClient(options);
+            var request = new RestRequest("/oauth/token", Method.Post);
+            request.AddJsonBody(new
+            {
+                client_id = authConfig.ClientId,
+                client_secret = authConfig.ClientSecret,
+                audience = authConfig.Audience,
+                grant_type = "client_credentials"
+            });
             var response = client.Execute(request);
-            var token = JsonConvert.DeserializeObject<Auth0Token>(response.Content);
-            return token;
+            return JsonConvert.DeserializeObject<Auth0Token>(response.Content);
         }
     }
 

--- a/src/FamUnion.Core/FamUnion.Core.csproj
+++ b/src/FamUnion.Core/FamUnion.Core.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.12" />
-	<PackageReference Include="Microsoft.AspNetCore.Authorization" Version="5.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="5.0.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="RestSharp" Version="106.11.7" />
+    <PackageReference Include="log4net" Version="2.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="RestSharp" Version="112.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/FamUnion.Infrastructure/DbAccess.cs
+++ b/src/FamUnion.Infrastructure/DbAccess.cs
@@ -1,7 +1,7 @@
 ﻿using FamUnion.Core.Validation;
 using System.Collections.Generic;
 using Dapper;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Data;
 using System.Threading.Tasks;
 

--- a/src/FamUnion.Infrastructure/FamUnion.Infrastructure.csproj
+++ b/src/FamUnion.Infrastructure/FamUnion.Infrastructure.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.78" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FamUnion.Infrastructure/ParameterDictionary.cs
+++ b/src/FamUnion.Infrastructure/ParameterDictionary.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Dynamic;
 using System.Linq;
 

--- a/src/FamUnion.WebAuth/Dockerfile
+++ b/src/FamUnion.WebAuth/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY ["FamUnion.WebAuth/FamUnion.WebAuth.csproj", "FamUnion.WebAuth/"]
 COPY ["FamUnion.Core/FamUnion.Core.csproj", "FamUnion.Core/"]

--- a/src/FamUnion.WebAuth/FamUnion.WebAuth.csproj
+++ b/src/FamUnion.WebAuth/FamUnion.WebAuth.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <UserSecretsId>45ab9587-9c7d-43ef-a742-aaab8044c865</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.3" />
-	  <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FamUnion.WebAuth/Startup.cs
+++ b/src/FamUnion.WebAuth/Startup.cs
@@ -13,7 +13,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
-using RestSharp.Serialization;
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -161,7 +160,7 @@ namespace FamUnion.WebAuth
                                 LastName = authResp.family_name
                             };
 
-                            var userContent = new StringContent(JsonConvert.SerializeObject(newUser), Encoding.UTF8, ContentType.Json);
+                            var userContent = new StringContent(JsonConvert.SerializeObject(newUser), Encoding.UTF8, "application/json");
                             var postResp = await appClient.PostAsync("users", userContent);
                         }
                     }


### PR DESCRIPTION
## Summary

- Upgrades all backend projects to `net10.0` (from `net6.0`, `netstandard2.1`, and `netcoreapp6.0`)
- Updates all Microsoft.AspNetCore.* and Microsoft.Extensions.* packages to `10.0.0`
- Replaces the deprecated `System.Data.SqlClient` package with `Microsoft.Data.SqlClient 6.0.1`
- Migrates RestSharp from v106 to v112 (major API rewrite) with required code fixes
- Updates Docker base images to `dotnet/aspnet:10.0` and `dotnet/sdk:10.0`
- Updates GitHub Actions to `actions/setup-dotnet@v4` / `actions/checkout@v4` targeting `dotnet-version: 10.0.x`

## Changed files

| File | Change |
|---|---|
| `FamUnion.Api.csproj` | `net6.0` → `net10.0`; package versions bumped |
| `FamUnion.Core.csproj` | `netstandard2.1` → `net10.0`; packages bumped; RestSharp 106 → 112 |
| `FamUnion.Infrastructure.csproj` | `netstandard2.1` → `net10.0`; `System.Data.SqlClient` → `Microsoft.Data.SqlClient 6.0.1`; Dapper 2.0 → 2.1 |
| `FamUnion.Core.Tests.csproj` | `netcoreapp6.0` → `net10.0`; xunit + test SDK bumped |
| `FamUnion.WebAuth.csproj` | `net6.0` → `net10.0`; packages bumped |
| `FamUnion.Api/Dockerfile` | Base images → `dotnet/aspnet:10.0` / `dotnet/sdk:10.0` |
| `FamUnion.WebAuth/Dockerfile` | Base images → `dotnet/aspnet:10.0` / `dotnet/sdk:10.0` |
| `.github/workflows/dotnetcore.yml` | `setup-dotnet@v4`, `dotnet-version: 10.0.x`, `checkout@v4` |
| `.github/workflows/dotnetcoretest.yml` | Same as above |
| `FamUnion.Core/Auth/TokenHelper.cs` | RestSharp v106 API → v112: `RestClientOptions`, `Method.Post`, `AddJsonBody` |
| `FamUnion.Infrastructure/DbAccess.cs` | `using System.Data.SqlClient` → `using Microsoft.Data.SqlClient` |
| `FamUnion.Infrastructure/ParameterDictionary.cs` | Same namespace swap |
| `FamUnion.Api/Controllers/ReunionsController.cs` | Remove `using RestSharp.Serialization`; `ContentType.Json` → `"application/json"` |
| `FamUnion.WebAuth/Startup.cs` | Same RestSharp.Serialization removal and ContentType fix |

## Notes

- The legacy `FamUnion` MVC project (targeting `netcoreapp2.1`) is not included in `FamUnion.sln` and was left unchanged.
- NSwag was bumped from 13.x to 14.x — if `UseSwaggerUi3` has been renamed in NSwag 14, a follow-up fix to `Startup.cs` may be needed.

## Test plan

- [ ] `dotnet build src/FamUnion.sln -c Release` passes
- [ ] `dotnet test src/FamUnion.sln -c Release` passes
- [ ] Docker images build successfully: `docker compose build`
- [ ] API health endpoint (`/health`) responds after startup
- [ ] Auth0 token flow works end-to-end in a staging environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ffUqiLWXrsEQxA6pqDJhg

---
_Generated by [Claude Code](https://claude.ai/code/session_011ffUqiLWXrsEQxA6pqDJhg)_