### PR TITLE
Transition database layer from SQL Server to PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ project.fragment.lock.json
 artifacts/
 **/Properties/launchSettings.json
 appsettings.Development.json
+.env
 
 # StyleCop
 StyleCopReport.xml

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to .env and fill in values before running docker-compose.
+# .env is gitignored and must never be committed.
+
+POSTGRES_DB=famunion
+POSTGRES_USER=famunion
+POSTGRES_PASSWORD=change_me

--- a/src/FamUnion.Api/FamUnion.Api.csproj
+++ b/src/FamUnion.Api/FamUnion.Api.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.0" />

--- a/src/FamUnion.Api/Startup.cs
+++ b/src/FamUnion.Api/Startup.cs
@@ -1,4 +1,5 @@
-﻿using FamUnion.Core.Auth;
+﻿using Dapper;
+using FamUnion.Core.Auth;
 using FamUnion.Core.Interface;
 using FamUnion.Core.Interface.Repository;
 using FamUnion.Core.Interface.Services;
@@ -37,11 +38,15 @@ namespace FamUnion.Api
         {
             // DB Connection
             var dbConnection = Configuration.GetConnectionString(ConfigSections.DbKey);
+
+            // Enable snake_case → PascalCase column mapping for Dapper
+            DefaultTypeMap.MatchNamesWithUnderscores = true;
+
             ConfigureRepositories(services, dbConnection);
 
             // Health Checks
             services.AddHealthChecks()
-                .AddSqlServer(dbConnection);
+                .AddNpgSql(dbConnection);
 
             // Services
             services.AddTransient<IReunionService, ReunionService>();

--- a/src/FamUnion.Api/appsettings.json
+++ b/src/FamUnion.Api/appsettings.json
@@ -5,7 +5,7 @@
     }
   },
   "ConnectionStrings": {
-    "FamUnionDb": "Host=localhost;Port=5432;Database=famunion;Username=famunion;Password=famunion"
+    "FamUnionDb": "Host=localhost;Port=5432;Database=famunion"
   },
   "AppAuth": {
     "Name": "App",

--- a/src/FamUnion.Api/appsettings.json
+++ b/src/FamUnion.Api/appsettings.json
@@ -5,7 +5,7 @@
     }
   },
   "ConnectionStrings": {
-    "FamUnionDb": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=FamUnion;Integrated Security=True;"
+    "FamUnionDb": "Host=localhost;Port=5432;Database=famunion;Username=famunion;Password=famunion"
   },
   "AppAuth": {
     "Name": "App",

--- a/src/FamUnion.Db/Postgres/V1__tables.sql
+++ b/src/FamUnion.Db/Postgres/V1__tables.sql
@@ -1,0 +1,98 @@
+-- entity_type: no dependencies
+CREATE TABLE entity_type (
+    entity_type_id INT          NOT NULL PRIMARY KEY,
+    entity_name    VARCHAR(255) NOT NULL,
+    is_active      BOOLEAN      NOT NULL DEFAULT TRUE
+);
+
+-- app_user: no dependencies
+CREATE TABLE app_user (
+    id           UUID         NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id      VARCHAR(100) NOT NULL UNIQUE,
+    first_name   VARCHAR(100),
+    last_name    VARCHAR(100),
+    email        VARCHAR(255) NOT NULL,
+    phone_number VARCHAR(15),
+    auth_type    INT          NOT NULL,
+    created_by   VARCHAR(100) NOT NULL,
+    created_date TIMESTAMP    NOT NULL DEFAULT NOW(),
+    modified_by  VARCHAR(100),
+    modified_date TIMESTAMP
+);
+
+-- address: depends on entity_type
+CREATE TABLE address (
+    address_id    UUID         NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_id     UUID         NOT NULL,
+    entity_type   INT          NOT NULL REFERENCES entity_type(entity_type_id),
+    description   VARCHAR(255) NOT NULL,
+    line1         VARCHAR(100),
+    line2         VARCHAR(100),
+    city          VARCHAR(100) NOT NULL,
+    state         VARCHAR(2)   NOT NULL,
+    zip_code      VARCHAR(5),
+    latitude      BIGINT,
+    longitude     BIGINT,
+    is_active     BOOLEAN      NOT NULL DEFAULT TRUE,
+    created_by    VARCHAR(100) NOT NULL,
+    created_date  TIMESTAMP    NOT NULL DEFAULT NOW(),
+    modified_by   VARCHAR(100),
+    modified_date TIMESTAMP
+);
+
+CREATE INDEX ix_address_entity ON address(entity_id, entity_type) WHERE is_active = TRUE;
+
+-- reunion: depends on address
+CREATE TABLE reunion (
+    reunion_id    UUID          NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    name          VARCHAR(100)  NOT NULL,
+    description   VARCHAR(4000),
+    start_date    DATE,
+    end_date      DATE,
+    address_id    UUID          REFERENCES address(address_id),
+    is_active     BOOLEAN       NOT NULL DEFAULT TRUE,
+    created_by    VARCHAR(100)  NOT NULL DEFAULT CURRENT_USER,
+    created_date  TIMESTAMP     NOT NULL DEFAULT NOW(),
+    modified_by   VARCHAR(100),
+    modified_date TIMESTAMP
+);
+
+-- events: depends on reunion and address
+CREATE TABLE events (
+    event_id      UUID          NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    reunion_id    UUID          NOT NULL REFERENCES reunion(reunion_id),
+    name          VARCHAR(255)  NOT NULL,
+    details       VARCHAR(2000),
+    start_time    TIMESTAMP     NOT NULL,
+    end_time      TIMESTAMP,
+    attire_type   INT           NOT NULL DEFAULT 0,
+    address_id    UUID          REFERENCES address(address_id),
+    is_active     BOOLEAN       NOT NULL DEFAULT TRUE,
+    created_by    VARCHAR(100)  NOT NULL,
+    created_date  TIMESTAMP     NOT NULL DEFAULT NOW(),
+    modified_by   VARCHAR(100),
+    modified_date TIMESTAMP
+);
+
+-- reunion_invite: depends on reunion
+CREATE TABLE reunion_invite (
+    invite_id     UUID         NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    reunion_id    UUID         NOT NULL REFERENCES reunion(reunion_id),
+    email         VARCHAR(255) NOT NULL,
+    name          VARCHAR(255),
+    rsvp_count    INT          NOT NULL DEFAULT 0,
+    status        INT          NOT NULL DEFAULT 0,
+    created_by    VARCHAR(100) NOT NULL DEFAULT CURRENT_USER,
+    created_date  TIMESTAMP    NOT NULL DEFAULT NOW(),
+    modified_by   VARCHAR(100),
+    modified_date TIMESTAMP,
+    UNIQUE (reunion_id, email)
+);
+
+-- reunion_organizer: depends on reunion and app_user
+CREATE TABLE reunion_organizer (
+    reunion_id UUID    NOT NULL REFERENCES reunion(reunion_id),
+    user_id    UUID    NOT NULL REFERENCES app_user(id),
+    is_active  BOOLEAN NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (reunion_id, user_id)
+);

--- a/src/FamUnion.Db/Postgres/V2__functions.sql
+++ b/src/FamUnion.Db/Postgres/V2__functions.sql
@@ -88,7 +88,7 @@ LANGUAGE sql AS $$
         r.modified_by,
         r.modified_date
     FROM reunion r
-    JOIN reunion_organizer ro ON ro.reunion_id = r.reunion_id
+    JOIN reunion_organizer ro ON ro.reunion_id = r.reunion_id AND ro.is_active = TRUE
     JOIN app_user u           ON ro.user_id = u.id
     WHERE r.is_active = TRUE
       AND u.user_id = p_user_id
@@ -211,7 +211,8 @@ LANGUAGE sql AS $$
         modified_by,
         modified_date
     FROM events
-    WHERE event_id = p_id;
+    WHERE event_id = p_id
+      AND is_active = TRUE;
 $$;
 
 CREATE OR REPLACE FUNCTION sp_get_events_by_reunion_id(p_reunion_id UUID)
@@ -245,6 +246,7 @@ LANGUAGE sql AS $$
         modified_date
     FROM events
     WHERE reunion_id = p_reunion_id
+      AND is_active = TRUE
     ORDER BY start_time, name;
 $$;
 
@@ -313,6 +315,46 @@ $$;
 -- ============================================================
 -- Address functions
 -- ============================================================
+
+CREATE OR REPLACE FUNCTION sp_get_address_by_id(p_address_id UUID)
+RETURNS TABLE (
+    id            UUID,
+    address_type  INT,
+    description   VARCHAR,
+    entity_type   INT,
+    line1         VARCHAR,
+    line2         VARCHAR,
+    city          VARCHAR,
+    state         VARCHAR,
+    zip_code      VARCHAR,
+    latitude      BIGINT,
+    longitude     BIGINT,
+    created_by    VARCHAR,
+    created_date  TIMESTAMP,
+    modified_by   VARCHAR,
+    modified_date TIMESTAMP
+)
+LANGUAGE sql AS $$
+    SELECT
+        a.address_id,
+        a.entity_type,
+        a.description,
+        a.entity_type,
+        a.line1,
+        a.line2,
+        a.city,
+        a.state,
+        a.zip_code,
+        a.latitude,
+        a.longitude,
+        a.created_by,
+        a.created_date,
+        a.modified_by,
+        a.modified_date
+    FROM address a
+    WHERE a.address_id = p_address_id
+      AND a.is_active  = TRUE;
+$$;
 
 CREATE OR REPLACE FUNCTION sp_get_address_by_entity_type_and_id(p_entity_type_id INT, p_entity_id UUID)
 RETURNS TABLE (

--- a/src/FamUnion.Db/Postgres/V2__functions.sql
+++ b/src/FamUnion.Db/Postgres/V2__functions.sql
@@ -1,0 +1,762 @@
+-- ============================================================
+-- Reunion functions
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION sp_get_reunion_by_id(p_id UUID)
+RETURNS TABLE (
+    id            UUID,
+    name          VARCHAR,
+    description   VARCHAR,
+    start_date    DATE,
+    end_date      DATE,
+    address_id    UUID,
+    created_by    VARCHAR,
+    created_date  TIMESTAMP,
+    modified_by   VARCHAR,
+    modified_date TIMESTAMP
+)
+LANGUAGE sql AS $$
+    SELECT
+        reunion_id,
+        name,
+        description,
+        start_date,
+        end_date,
+        address_id,
+        created_by,
+        created_date,
+        modified_by,
+        modified_date
+    FROM reunion
+    WHERE reunion_id = p_id
+      AND is_active = TRUE;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_get_reunions()
+RETURNS TABLE (
+    id            UUID,
+    name          VARCHAR,
+    description   VARCHAR,
+    start_date    DATE,
+    end_date      DATE,
+    address_id    UUID,
+    created_by    VARCHAR,
+    created_date  TIMESTAMP,
+    modified_by   VARCHAR,
+    modified_date TIMESTAMP
+)
+LANGUAGE sql AS $$
+    SELECT
+        reunion_id,
+        name,
+        description,
+        start_date,
+        end_date,
+        address_id,
+        created_by,
+        created_date,
+        modified_by,
+        modified_date
+    FROM reunion
+    WHERE is_active = TRUE
+    ORDER BY start_date, name;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_get_manage_reunions(p_user_id VARCHAR)
+RETURNS TABLE (
+    id            UUID,
+    name          VARCHAR,
+    description   VARCHAR,
+    start_date    DATE,
+    end_date      DATE,
+    address_id    UUID,
+    created_by    VARCHAR,
+    created_date  TIMESTAMP,
+    modified_by   VARCHAR,
+    modified_date TIMESTAMP
+)
+LANGUAGE sql AS $$
+    SELECT
+        r.reunion_id,
+        r.name,
+        r.description,
+        r.start_date,
+        r.end_date,
+        r.address_id,
+        r.created_by,
+        r.created_date,
+        r.modified_by,
+        r.modified_date
+    FROM reunion r
+    JOIN reunion_organizer ro ON ro.reunion_id = r.reunion_id
+    JOIN app_user u           ON ro.user_id = u.id
+    WHERE r.is_active = TRUE
+      AND u.user_id = p_user_id
+    ORDER BY r.start_date, r.name;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_save_reunion(
+    p_id          UUID,
+    p_user_id     VARCHAR,
+    p_name        VARCHAR,
+    p_description VARCHAR,
+    p_start_date  DATE,
+    p_end_date    DATE
+)
+RETURNS TABLE (
+    id            UUID,
+    name          VARCHAR,
+    description   VARCHAR,
+    start_date    DATE,
+    end_date      DATE,
+    address_id    UUID,
+    created_by    VARCHAR,
+    created_date  TIMESTAMP,
+    modified_by   VARCHAR,
+    modified_date TIMESTAMP
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO reunion (reunion_id, name, description, start_date, end_date, created_date, created_by)
+    VALUES (p_id, p_name, p_description, p_start_date, p_end_date, NOW(), p_user_id)
+    ON CONFLICT (reunion_id) DO UPDATE
+        SET name          = EXCLUDED.name,
+            description   = EXCLUDED.description,
+            start_date    = EXCLUDED.start_date,
+            end_date      = EXCLUDED.end_date,
+            modified_by   = p_user_id,
+            modified_date = NOW()
+        WHERE reunion.is_active = TRUE;
+
+    RETURN QUERY SELECT * FROM sp_get_reunion_by_id(p_id);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_delete_reunion_by_id(p_reunion_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE address
+    SET is_active     = FALSE,
+        modified_by   = CURRENT_USER,
+        modified_date = NOW()
+    WHERE entity_id   = p_reunion_id
+      AND entity_type = (SELECT entity_type_id FROM entity_type WHERE entity_name = 'Reunion');
+
+    UPDATE reunion
+    SET is_active     = FALSE,
+        modified_by   = CURRENT_USER,
+        modified_date = NOW()
+    WHERE reunion_id  = p_reunion_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_add_reunion_organizer(p_reunion_id UUID, p_email VARCHAR)
+RETURNS VOID
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO reunion_organizer (reunion_id, user_id)
+    SELECT p_reunion_id, id
+    FROM app_user
+    WHERE email = p_email
+    ON CONFLICT (reunion_id, user_id) DO UPDATE
+        SET is_active = TRUE;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_remove_reunion_organizer(p_reunion_id UUID, p_email VARCHAR)
+RETURNS VOID
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE reunion_organizer ro
+    SET is_active = FALSE
+    FROM app_user u
+    WHERE ro.reunion_id = p_reunion_id
+      AND ro.user_id    = u.id
+      AND u.email       = p_email;
+END;
+$$;
+
+-- ============================================================
+-- Event functions
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION sp_get_event_by_id(p_id UUID)
+RETURNS TABLE (
+    id            UUID,
+    reunion_id    UUID,
+    name          VARCHAR,
+    details       VARCHAR,
+    start_time    TIMESTAMP,
+    end_time      TIMESTAMP,
+    attire_type   INT,
+    address_id    UUID,
+    created_by    VARCHAR,
+    created_date  TIMESTAMP,
+    modified_by   VARCHAR,
+    modified_date TIMESTAMP
+)
+LANGUAGE sql AS $$
+    SELECT
+        event_id,
+        reunion_id,
+        name,
+        details,
+        start_time,
+        end_time,
+        attire_type,
+        address_id,
+        created_by,
+        created_date,
+        modified_by,
+        modified_date
+    FROM events
+    WHERE event_id = p_id;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_get_events_by_reunion_id(p_reunion_id UUID)
+RETURNS TABLE (
+    id            UUID,
+    reunion_id    UUID,
+    name          VARCHAR,
+    details       VARCHAR,
+    start_time    TIMESTAMP,
+    end_time      TIMESTAMP,
+    attire_type   INT,
+    address_id    UUID,
+    created_by    VARCHAR,
+    created_date  TIMESTAMP,
+    modified_by   VARCHAR,
+    modified_date TIMESTAMP
+)
+LANGUAGE sql AS $$
+    SELECT
+        event_id,
+        reunion_id,
+        name,
+        details,
+        start_time,
+        end_time,
+        attire_type,
+        address_id,
+        created_by,
+        created_date,
+        modified_by,
+        modified_date
+    FROM events
+    WHERE reunion_id = p_reunion_id
+    ORDER BY start_time, name;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_save_event(
+    p_user_id    VARCHAR,
+    p_id         UUID,
+    p_reunion_id UUID,
+    p_name       VARCHAR,
+    p_details    VARCHAR,
+    p_start_time TIMESTAMP,
+    p_end_time   TIMESTAMP,
+    p_attire_type INT
+)
+RETURNS TABLE (
+    id            UUID,
+    reunion_id    UUID,
+    name          VARCHAR,
+    details       VARCHAR,
+    start_time    TIMESTAMP,
+    end_time      TIMESTAMP,
+    attire_type   INT,
+    address_id    UUID,
+    created_by    VARCHAR,
+    created_date  TIMESTAMP,
+    modified_by   VARCHAR,
+    modified_date TIMESTAMP
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO events (event_id, reunion_id, name, details, start_time, end_time, attire_type, created_date, created_by)
+    VALUES (p_id, p_reunion_id, p_name, p_details, p_start_time, p_end_time, p_attire_type, NOW(), p_user_id)
+    ON CONFLICT (event_id) DO UPDATE
+        SET name          = EXCLUDED.name,
+            reunion_id    = EXCLUDED.reunion_id,
+            details       = EXCLUDED.details,
+            start_time    = EXCLUDED.start_time,
+            end_time      = EXCLUDED.end_time,
+            attire_type   = EXCLUDED.attire_type,
+            modified_by   = p_user_id,
+            modified_date = NOW()
+        WHERE events.is_active = TRUE;
+
+    RETURN QUERY SELECT * FROM sp_get_event_by_id(p_id);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_cancel_event_by_id(p_user_id VARCHAR, p_event_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE address
+    SET is_active     = FALSE,
+        modified_by   = p_user_id,
+        modified_date = NOW()
+    WHERE entity_id   = p_event_id
+      AND entity_type = (SELECT entity_type_id FROM entity_type WHERE entity_name = 'Event');
+
+    UPDATE events
+    SET is_active     = FALSE,
+        modified_by   = p_user_id,
+        modified_date = NOW()
+    WHERE event_id    = p_event_id;
+END;
+$$;
+
+-- ============================================================
+-- Address functions
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION sp_get_address_by_entity_type_and_id(p_entity_type_id INT, p_entity_id UUID)
+RETURNS TABLE (
+    id            UUID,
+    address_type  INT,
+    description   VARCHAR,
+    entity_type   INT,
+    line1         VARCHAR,
+    line2         VARCHAR,
+    city          VARCHAR,
+    state         VARCHAR,
+    zip_code      VARCHAR,
+    latitude      BIGINT,
+    longitude     BIGINT,
+    created_by    VARCHAR,
+    created_date  TIMESTAMP,
+    modified_by   VARCHAR,
+    modified_date TIMESTAMP
+)
+LANGUAGE sql AS $$
+    SELECT
+        a.address_id,
+        p_entity_type_id,
+        a.description,
+        a.entity_type,
+        a.line1,
+        a.line2,
+        a.city,
+        a.state,
+        a.zip_code,
+        a.latitude,
+        a.longitude,
+        a.created_by,
+        a.created_date,
+        a.modified_by,
+        a.modified_date
+    FROM address a
+    WHERE a.entity_type = p_entity_type_id
+      AND a.entity_id   = p_entity_id
+      AND a.is_active   = TRUE;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_get_address_by_event_id(p_event_id UUID)
+RETURNS TABLE (
+    id            UUID,
+    address_type  INT,
+    description   VARCHAR,
+    entity_type   INT,
+    line1         VARCHAR,
+    line2         VARCHAR,
+    city          VARCHAR,
+    state         VARCHAR,
+    zip_code      VARCHAR,
+    latitude      BIGINT,
+    longitude     BIGINT,
+    created_by    VARCHAR,
+    created_date  TIMESTAMP,
+    modified_by   VARCHAR,
+    modified_date TIMESTAMP
+)
+LANGUAGE sql AS $$
+    SELECT * FROM sp_get_address_by_entity_type_and_id(
+        (SELECT entity_type_id FROM entity_type WHERE entity_name = 'Event'),
+        p_event_id
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION sp_get_address_by_reunion_id(p_reunion_id UUID)
+RETURNS TABLE (
+    id            UUID,
+    address_type  INT,
+    description   VARCHAR,
+    entity_type   INT,
+    line1         VARCHAR,
+    line2         VARCHAR,
+    city          VARCHAR,
+    state         VARCHAR,
+    zip_code      VARCHAR,
+    latitude      BIGINT,
+    longitude     BIGINT,
+    created_by    VARCHAR,
+    created_date  TIMESTAMP,
+    modified_by   VARCHAR,
+    modified_date TIMESTAMP
+)
+LANGUAGE sql AS $$
+    SELECT * FROM sp_get_address_by_entity_type_and_id(
+        (SELECT entity_type_id FROM entity_type WHERE entity_name = 'Reunion'),
+        p_reunion_id
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION sp_save_address_by_entity_type_and_id(
+    p_user_id     VARCHAR,
+    p_entity_type VARCHAR,
+    p_entity_id   UUID,
+    p_description VARCHAR,
+    p_line1       VARCHAR,
+    p_line2       VARCHAR,
+    p_city        VARCHAR,
+    p_state       VARCHAR,
+    p_zip_code    VARCHAR
+)
+RETURNS VOID
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_entity_type_id INT;
+    v_address_id     UUID;
+BEGIN
+    SELECT entity_type_id INTO v_entity_type_id
+    FROM entity_type
+    WHERE entity_name = p_entity_type;
+
+    SELECT address_id INTO v_address_id
+    FROM address
+    WHERE entity_id   = p_entity_id
+      AND entity_type = v_entity_type_id
+      AND is_active   = TRUE
+    LIMIT 1;
+
+    IF v_address_id IS NOT NULL THEN
+        UPDATE address
+        SET description   = p_description,
+            line1         = p_line1,
+            line2         = p_line2,
+            city          = p_city,
+            state         = p_state,
+            zip_code      = p_zip_code,
+            modified_by   = p_user_id,
+            modified_date = NOW()
+        WHERE address_id  = v_address_id;
+    ELSE
+        INSERT INTO address (
+            address_id, entity_id, entity_type, description,
+            line1, line2, city, state, zip_code,
+            created_date, created_by
+        )
+        VALUES (
+            gen_random_uuid(), p_entity_id, v_entity_type_id, p_description,
+            p_line1, p_line2, p_city, p_state, p_zip_code,
+            NOW(), p_user_id
+        );
+    END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_save_reunion_address(
+    p_user_id     VARCHAR,
+    p_reunion_id  UUID,
+    p_description VARCHAR,
+    p_line1       VARCHAR,
+    p_line2       VARCHAR,
+    p_city        VARCHAR,
+    p_state       VARCHAR,
+    p_zip_code    VARCHAR
+)
+RETURNS TABLE (
+    id            UUID,
+    address_type  INT,
+    description   VARCHAR,
+    entity_type   INT,
+    line1         VARCHAR,
+    line2         VARCHAR,
+    city          VARCHAR,
+    state         VARCHAR,
+    zip_code      VARCHAR,
+    latitude      BIGINT,
+    longitude     BIGINT,
+    created_by    VARCHAR,
+    created_date  TIMESTAMP,
+    modified_by   VARCHAR,
+    modified_date TIMESTAMP
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    PERFORM sp_save_address_by_entity_type_and_id(
+        p_user_id, 'Reunion', p_reunion_id,
+        p_description, p_line1, p_line2, p_city, p_state, p_zip_code
+    );
+    RETURN QUERY SELECT * FROM sp_get_address_by_reunion_id(p_reunion_id);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_save_event_address(
+    p_user_id     VARCHAR,
+    p_event_id    UUID,
+    p_description VARCHAR,
+    p_line1       VARCHAR,
+    p_line2       VARCHAR,
+    p_city        VARCHAR,
+    p_state       VARCHAR,
+    p_zip_code    VARCHAR
+)
+RETURNS TABLE (
+    id            UUID,
+    address_type  INT,
+    description   VARCHAR,
+    entity_type   INT,
+    line1         VARCHAR,
+    line2         VARCHAR,
+    city          VARCHAR,
+    state         VARCHAR,
+    zip_code      VARCHAR,
+    latitude      BIGINT,
+    longitude     BIGINT,
+    created_by    VARCHAR,
+    created_date  TIMESTAMP,
+    modified_by   VARCHAR,
+    modified_date TIMESTAMP
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    PERFORM sp_save_address_by_entity_type_and_id(
+        p_user_id, 'Event', p_event_id,
+        p_description, p_line1, p_line2, p_city, p_state, p_zip_code
+    );
+    RETURN QUERY SELECT * FROM sp_get_address_by_event_id(p_event_id);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_delete_address_by_id(p_address_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE address
+    SET is_active     = FALSE,
+        modified_by   = CURRENT_USER,
+        modified_date = NOW()
+    WHERE address_id  = p_address_id;
+END;
+$$;
+
+-- ============================================================
+-- User functions
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION sp_get_user_by_id(p_user_id VARCHAR)
+RETURNS TABLE (
+    id           UUID,
+    user_id      VARCHAR,
+    first_name   VARCHAR,
+    last_name    VARCHAR,
+    email        VARCHAR,
+    phone_number VARCHAR,
+    auth_type    INT
+)
+LANGUAGE sql AS $$
+    SELECT id, user_id, first_name, last_name, email, phone_number, auth_type
+    FROM app_user
+    WHERE user_id = p_user_id;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_get_user_by_email(p_email VARCHAR)
+RETURNS TABLE (
+    id           UUID,
+    user_id      VARCHAR,
+    first_name   VARCHAR,
+    last_name    VARCHAR,
+    email        VARCHAR,
+    phone_number VARCHAR,
+    auth_type    INT
+)
+LANGUAGE sql AS $$
+    SELECT id, user_id, first_name, last_name, email, phone_number, auth_type
+    FROM app_user
+    WHERE email = p_email;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_save_user(
+    p_id        UUID,
+    p_user_id   VARCHAR,
+    p_email     VARCHAR,
+    p_first_name VARCHAR,
+    p_last_name  VARCHAR,
+    p_auth_type  INT
+)
+RETURNS TABLE (
+    id           UUID,
+    user_id      VARCHAR,
+    first_name   VARCHAR,
+    last_name    VARCHAR,
+    email        VARCHAR,
+    phone_number VARCHAR,
+    auth_type    INT
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO app_user (id, user_id, email, first_name, last_name, auth_type, created_date, created_by)
+    VALUES (p_id, p_user_id, p_email, p_first_name, p_last_name, p_auth_type, NOW(), CURRENT_USER)
+    ON CONFLICT (user_id) DO UPDATE
+        SET email         = EXCLUDED.email,
+            first_name    = EXCLUDED.first_name,
+            last_name     = EXCLUDED.last_name,
+            modified_by   = CURRENT_USER,
+            modified_date = NOW();
+
+    RETURN QUERY SELECT * FROM sp_get_user_by_id(p_user_id);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_get_organizers_by_reunion_id(p_reunion_id UUID)
+RETURNS TABLE (
+    user_id      VARCHAR,
+    first_name   VARCHAR,
+    last_name    VARCHAR,
+    email        VARCHAR,
+    phone_number VARCHAR,
+    auth_type    INT
+)
+LANGUAGE sql AS $$
+    SELECT u.user_id, u.first_name, u.last_name, u.email, u.phone_number, u.auth_type
+    FROM reunion_organizer ro
+    JOIN app_user u ON ro.user_id = u.id AND ro.is_active = TRUE
+    WHERE ro.reunion_id = p_reunion_id;
+$$;
+
+-- ============================================================
+-- Attendee / invite functions
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION sp_get_invites_by_reunion_id(p_reunion_id UUID)
+RETURNS TABLE (
+    id         UUID,
+    reunion_id UUID,
+    email      VARCHAR,
+    name       VARCHAR,
+    rsvp_count INT,
+    status     INT
+)
+LANGUAGE sql AS $$
+    SELECT invite_id, reunion_id, email, name, rsvp_count, status
+    FROM reunion_invite
+    WHERE reunion_id = p_reunion_id
+    ORDER BY email;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_get_invite_by_id(p_invite_id UUID)
+RETURNS TABLE (
+    id         UUID,
+    reunion_id UUID,
+    email      VARCHAR,
+    name       VARCHAR,
+    rsvp_count INT,
+    status     INT
+)
+LANGUAGE sql AS $$
+    SELECT invite_id, reunion_id, email, name, rsvp_count, status
+    FROM reunion_invite
+    WHERE invite_id = p_invite_id;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_create_invites(p_invites TEXT, p_user_id VARCHAR)
+RETURNS VOID
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO reunion_invite (invite_id, reunion_id, email, name, created_by, created_date)
+    SELECT
+        gen_random_uuid(),
+        (item->>'reunion_id')::UUID,
+        item->>'email',
+        item->>'name',
+        p_user_id,
+        NOW()
+    FROM jsonb_array_elements(p_invites::jsonb) AS item
+    ON CONFLICT (reunion_id, email) DO NOTHING;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_update_invite_status(p_invite_id UUID, p_status INT)
+RETURNS VOID
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE reunion_invite
+    SET status        = p_status,
+        modified_date = NOW(),
+        modified_by   = CURRENT_USER
+    WHERE invite_id   = p_invite_id;
+END;
+$$;
+
+-- ============================================================
+-- User access functions
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION sp_user_has_read_access_to_entity(
+    p_user_id    VARCHAR,
+    p_entity_type INT,
+    p_entity_id  UUID
+)
+RETURNS TABLE (result BOOLEAN)
+LANGUAGE plpgsql AS $$
+BEGIN
+    -- Reunion entity
+    IF p_entity_type = 1 THEN
+        RETURN QUERY
+        SELECT COUNT(1) > 0
+        FROM reunion r
+        JOIN reunion_organizer ro ON r.reunion_id = ro.reunion_id
+            AND r.reunion_id = p_entity_id
+            AND r.is_active  = TRUE
+            AND ro.is_active = TRUE
+        JOIN app_user u ON ro.user_id = u.id AND u.user_id = p_user_id;
+    END IF;
+
+    -- Event entity
+    IF p_entity_type = 2 THEN
+        RETURN QUERY
+        SELECT COUNT(1) > 0
+        FROM events e
+        JOIN reunion r          ON e.reunion_id = r.reunion_id AND e.event_id = p_entity_id AND e.is_active = TRUE
+        JOIN reunion_organizer ro ON r.reunion_id = ro.reunion_id AND ro.is_active = TRUE
+        JOIN app_user u         ON ro.user_id = u.id AND u.user_id = p_user_id;
+    END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sp_user_has_write_access_to_entity(
+    p_user_id     VARCHAR,
+    p_entity_type INT,
+    p_entity_id   UUID
+)
+RETURNS TABLE (result BOOLEAN)
+LANGUAGE plpgsql AS $$
+BEGIN
+    -- Reunion entity
+    IF p_entity_type = 1 THEN
+        RETURN QUERY
+        SELECT COUNT(1) > 0
+        FROM reunion r
+        JOIN reunion_organizer ro ON r.reunion_id = ro.reunion_id
+            AND r.reunion_id = p_entity_id
+            AND r.is_active  = TRUE
+            AND ro.is_active = TRUE
+        JOIN app_user u ON ro.user_id = u.id AND u.user_id = p_user_id;
+    END IF;
+
+    -- Event entity
+    IF p_entity_type = 2 THEN
+        RETURN QUERY
+        SELECT COUNT(1) > 0
+        FROM events e
+        JOIN reunion r          ON e.reunion_id = r.reunion_id AND e.event_id = p_entity_id AND e.is_active = TRUE
+        JOIN reunion_organizer ro ON r.reunion_id = ro.reunion_id AND ro.is_active = TRUE
+        JOIN app_user u         ON ro.user_id = u.id AND u.user_id = p_user_id;
+    END IF;
+END;
+$$;

--- a/src/FamUnion.Db/Postgres/V3__seed.sql
+++ b/src/FamUnion.Db/Postgres/V3__seed.sql
@@ -1,0 +1,7 @@
+INSERT INTO entity_type (entity_type_id, entity_name, is_active) VALUES
+    (1, 'Reunion', TRUE),
+    (2, 'Event',   TRUE),
+    (3, 'Family',  FALSE),
+    (4, 'Lodging', TRUE)
+ON CONFLICT (entity_type_id) DO UPDATE
+    SET is_active = EXCLUDED.is_active;

--- a/src/FamUnion.Infrastructure/DbAccess.cs
+++ b/src/FamUnion.Infrastructure/DbAccess.cs
@@ -1,7 +1,7 @@
-﻿using FamUnion.Core.Validation;
+using FamUnion.Core.Validation;
 using System.Collections.Generic;
 using Dapper;
-using Microsoft.Data.SqlClient;
+using Npgsql;
 using System.Data;
 using System.Threading.Tasks;
 
@@ -9,83 +9,73 @@ namespace FamUnion.Infrastructure
 {
     public class DbAccess<T>
     {
-        private string _connectionString;
-
-        private static readonly CommandType _sProcType = CommandType.StoredProcedure;
+        private readonly string _connectionString;
 
         public DbAccess(string connectionString)
         {
             _connectionString = Validator.ThrowIfNull(connectionString, nameof(connectionString));
-        }        
-
-        protected async Task<IEnumerable<T>> ExecuteStoredProc(string proc, IDataMapper<T> mapper, ParameterDictionary parameters)
-        {
-            return await Execute(proc, mapper, parameters)
-                .ConfigureAwait(continueOnCapturedContext: false);
         }
 
-        protected async Task<IEnumerable<T>> ExecuteStoredProc(string proc, IDataMapper<T> mapper)
+        protected async Task<IEnumerable<T>> ExecuteStoredProc(string sql, IDataMapper<T> mapper, ParameterDictionary parameters)
         {
-            return await Execute(proc, mapper, null)
-                .ConfigureAwait(continueOnCapturedContext: false);
+            return await Execute(sql, mapper, parameters).ConfigureAwait(false);
         }
 
-        protected async Task<IEnumerable<T>> ExecuteStoredProc(string proc, ParameterDictionary parameters)
+        protected async Task<IEnumerable<T>> ExecuteStoredProc(string sql, IDataMapper<T> mapper)
         {
-            return await Execute(proc, null, parameters)
-                .ConfigureAwait(continueOnCapturedContext: false);
+            return await Execute(sql, mapper, null).ConfigureAwait(false);
         }
 
-        protected async Task<IEnumerable<T>> ExecuteStoredProc(string proc)
+        protected async Task<IEnumerable<T>> ExecuteStoredProc(string sql, ParameterDictionary parameters)
         {
-            return await Execute(proc, null, null)
-                .ConfigureAwait(continueOnCapturedContext: false);
+            return await Execute(sql, null, parameters).ConfigureAwait(false);
         }
 
-        private async Task<IEnumerable<T>> Execute(string proc, IDataMapper<T> mapper, ParameterDictionary parameters)
+        protected async Task<IEnumerable<T>> ExecuteStoredProc(string sql)
         {
-            //_logger.LogInformation($"DataAccess.Execute|Stored Proc: {proc}, Return type: {typeof(T).ToString()}, Data Mapper: {mapper?.GetType()?.ToString() ?? "N/A"}, Parameters: {parameters?.GetDynamicObject() ?? "N/A"}");
-            using (SqlConnection conn = new SqlConnection(_connectionString))
+            return await Execute(sql, null, null).ConfigureAwait(false);
+        }
+
+        protected async Task ExecuteNonQueryProc(string sql, ParameterDictionary parameters)
+        {
+            await using var conn = new NpgsqlConnection(_connectionString);
+            await conn.OpenAsync().ConfigureAwait(false);
+            await conn.ExecuteAsync(sql, parameters?.GetDynamicObject(), commandType: CommandType.Text)
+                .ConfigureAwait(false);
+        }
+
+        protected async Task ExecuteNonQueryProc(string sql)
+        {
+            await ExecuteNonQueryProc(sql, null).ConfigureAwait(false);
+        }
+
+        private async Task<IEnumerable<T>> Execute(string sql, IDataMapper<T> mapper, ParameterDictionary parameters)
+        {
+            await using var conn = new NpgsqlConnection(_connectionString);
+            await conn.OpenAsync().ConfigureAwait(false);
+
+            if (mapper != null)
             {
-                conn.Open();
-
-                if (mapper != null)
-                {
-                    SqlMapper.GridReader reader = await conn.QueryMultipleAsync(proc, parameters?.GetDynamicObject() ?? null, commandType: _sProcType)
-                        .ConfigureAwait(continueOnCapturedContext: false);
-
-                    return await mapper.MapDataAsync(reader)
-                        .ConfigureAwait(continueOnCapturedContext: false);
-                }
-                else if (parameters != null)
-                {
-                    return await conn.QueryAsync<T>(proc, parameters.GetDynamicObject(), commandType: _sProcType)
-                        .ConfigureAwait(continueOnCapturedContext: false);
-                }
-                else
-                {
-                    return await conn.QueryAsync<T>(proc, commandType: _sProcType)
-                        .ConfigureAwait(continueOnCapturedContext: false);
-                }
+                SqlMapper.GridReader reader = await conn.QueryMultipleAsync(sql, parameters?.GetDynamicObject(), commandType: CommandType.Text)
+                    .ConfigureAwait(false);
+                return await mapper.MapDataAsync(reader).ConfigureAwait(false);
             }
+
+            return await conn.QueryAsync<T>(sql, parameters?.GetDynamicObject(), commandType: CommandType.Text)
+                .ConfigureAwait(false);
         }
 
-        protected async Task<object> ExecuteScalar(string proc, ParameterDictionary parameters)
+        protected async Task<object> ExecuteScalar(string sql, ParameterDictionary parameters)
         {
-            return await ExecuteScalarWithTimeout(proc, parameters, null)
-                .ConfigureAwait(continueOnCapturedContext: false);
+            return await ExecuteScalarWithTimeout(sql, parameters, null).ConfigureAwait(false);
         }
 
-        protected async Task<object> ExecuteScalarWithTimeout(string proc, ParameterDictionary parameters, int? timeout)
+        protected async Task<object> ExecuteScalarWithTimeout(string sql, ParameterDictionary parameters, int? timeout)
         {
-            //_logger.LogInformation($"DataAccess.ExecuteScalarWithTimeout|Stored Proc: {proc}, Parameters: {parameters?.GetDynamicObject() ?? "N/A"}, Timeout: {timeout ?? 0}");
-            using (SqlConnection conn = new SqlConnection(_connectionString))
-            {
-                conn.Open();
-
-                return await conn.ExecuteScalarAsync(proc, parameters?.GetDynamicObject(), commandTimeout: timeout, commandType: _sProcType)
-                    .ConfigureAwait(continueOnCapturedContext: false);
-            }
+            await using var conn = new NpgsqlConnection(_connectionString);
+            await conn.OpenAsync().ConfigureAwait(false);
+            return await conn.ExecuteScalarAsync(sql, parameters?.GetDynamicObject(), commandTimeout: timeout, commandType: CommandType.Text)
+                .ConfigureAwait(false);
         }
     }
 }

--- a/src/FamUnion.Infrastructure/FamUnion.Infrastructure.csproj
+++ b/src/FamUnion.Infrastructure/FamUnion.Infrastructure.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.35" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Npgsql" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FamUnion.Infrastructure/ParameterDictionary.cs
+++ b/src/FamUnion.Infrastructure/ParameterDictionary.cs
@@ -1,7 +1,5 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Data.Common;
-using Microsoft.Data.SqlClient;
 using System.Dynamic;
 using System.Linq;
 
@@ -46,10 +44,7 @@ namespace FamUnion.Infrastructure
 
         public static ParameterDictionary Empty
         {
-            get
-            {
-                return new ParameterDictionary();
-            }
+            get { return new ParameterDictionary(); }
         }
 
         public static ParameterDictionary Single(string parameterName, object parameterValue)
@@ -71,7 +66,6 @@ namespace FamUnion.Infrastructure
         public void AddParameter(string parameterName, object value)
         {
             RemoveParameter(parameterName);
-
             _dictionary[parameterName] = value;
         }
 
@@ -80,14 +74,6 @@ namespace FamUnion.Infrastructure
             if (_dictionary.ContainsKey(parameterName))
             {
                 _dictionary.Remove(parameterName);
-            }
-        }
-
-        public void AddToCommand(DbCommand command)
-        {
-            foreach (KeyValuePair<string, object> kvp in _dictionary)
-            {
-                command.Parameters.Add(new SqlParameter(kvp.Key, kvp.Value));
             }
         }
 
@@ -105,5 +91,4 @@ namespace FamUnion.Infrastructure
             return eoDynamic;
         }
     }
-
 }

--- a/src/FamUnion.Infrastructure/Repository/AddressRepository.cs
+++ b/src/FamUnion.Infrastructure/Repository/AddressRepository.cs
@@ -16,12 +16,9 @@ namespace FamUnion.Infrastructure.Repository
 
         public async Task<Address> GetAddressAsync(Guid id)
         {
-            const string sql = "SELECT * FROM sp_get_address_by_entity_type_and_id(@entityTypeId, @entityId)";
-            ParameterDictionary parameters = new ParameterDictionary(
-                "entityTypeId", (int)EntityType.Reunion,
-                "entityId",     id
-            );
-            return (await ExecuteStoredProc(sql, parameters).ConfigureAwait(false)).SingleOrDefault();
+            const string sql = "SELECT * FROM sp_get_address_by_id(@id)";
+            return (await ExecuteStoredProc(sql, ParameterDictionary.Single("id", id))
+                .ConfigureAwait(false)).SingleOrDefault();
         }
 
         public async Task<Address> GetEventAddressAsync(Guid eventId)

--- a/src/FamUnion.Infrastructure/Repository/AddressRepository.cs
+++ b/src/FamUnion.Infrastructure/Repository/AddressRepository.cs
@@ -1,4 +1,4 @@
-﻿using FamUnion.Core.Interface;
+using FamUnion.Core.Interface;
 using FamUnion.Core.Model;
 using System;
 using System.Linq;
@@ -12,22 +12,23 @@ namespace FamUnion.Infrastructure.Repository
         public AddressRepository(string connection)
             : base(connection)
         {
-
         }
 
         public async Task<Address> GetAddressAsync(Guid id)
         {
-            ParameterDictionary parameters = ParameterDictionary.Single("id", id.ToString());
-
-            return (await ExecuteStoredProc("[dbo].[spGetAddressById]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false)).SingleOrDefault();
+            const string sql = "SELECT * FROM sp_get_address_by_entity_type_and_id(@entityTypeId, @entityId)";
+            ParameterDictionary parameters = new ParameterDictionary(
+                "entityTypeId", (int)EntityType.Reunion,
+                "entityId",     id
+            );
+            return (await ExecuteStoredProc(sql, parameters).ConfigureAwait(false)).SingleOrDefault();
         }
 
         public async Task<Address> GetEventAddressAsync(Guid eventId)
         {
-            ParameterDictionary parameters = ParameterDictionary.Single("eventId", eventId.ToString());
-            return (await ExecuteStoredProc("[dbo].[spGetAddressByEventId]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false)).SingleOrDefault();
+            const string sql = "SELECT * FROM sp_get_address_by_event_id(@eventId)";
+            return (await ExecuteStoredProc(sql, ParameterDictionary.Single("eventId", eventId))
+                .ConfigureAwait(false)).SingleOrDefault();
         }
 
         public Task<Address> GetLodgingAddressAsync(Guid lodgingId)
@@ -37,26 +38,26 @@ namespace FamUnion.Infrastructure.Repository
 
         public async Task<Address> GetReunionAddressAsync(Guid reunionId)
         {
-            ParameterDictionary parameters = ParameterDictionary.Single("entityTypeId", (int)EntityType.Reunion);
-            parameters.AddParameter("entityId", reunionId.ToString());
-            return (await ExecuteStoredProc("[dbo].[spGetAddressByEntityTypeAndId]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false)).SingleOrDefault();
+            const string sql = "SELECT * FROM sp_get_address_by_entity_type_and_id(@entityTypeId, @entityId)";
+            ParameterDictionary parameters = new ParameterDictionary(
+                "entityTypeId", (int)EntityType.Reunion,
+                "entityId",     reunionId
+            );
+            return (await ExecuteStoredProc(sql, parameters).ConfigureAwait(false)).SingleOrDefault();
         }
 
         public async Task<Address> SaveEventAddressAsync(Guid eventId, Address address)
         {
-            Address currentAddress = await GetEventAddressAsync(eventId)
-                .ConfigureAwait(continueOnCapturedContext: false);
+            Address currentAddress = await GetEventAddressAsync(eventId).ConfigureAwait(false);
 
             if (address is null || (currentAddress != null && currentAddress.Equals(address)))
             {
                 return currentAddress;
             }
 
+            const string sql = "SELECT * FROM sp_save_event_address(@userId, @eventId, @description, @line1, @line2, @city, @state, @zipcode)";
             ParameterDictionary parameters = GetAddressParameters(address, "eventId", eventId);
-
-            return (await ExecuteStoredProc("[dbo].[spSaveEventAddress]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false)).SingleOrDefault();
+            return (await ExecuteStoredProc(sql, parameters).ConfigureAwait(false)).SingleOrDefault();
         }
 
         public Task<Address> SaveLodgingAddressAsync(Guid lodgingId, Address address)
@@ -66,35 +67,32 @@ namespace FamUnion.Infrastructure.Repository
 
         public async Task<Address> SaveReunionAddressAsync(Guid reunionId, Address address)
         {
-            Address currentAddress = await GetReunionAddressAsync(reunionId).
-                ConfigureAwait(continueOnCapturedContext: false);
+            Address currentAddress = await GetReunionAddressAsync(reunionId).ConfigureAwait(false);
 
-            if(address is null || (currentAddress != null && currentAddress.Equals(address)))
+            if (address is null || (currentAddress != null && currentAddress.Equals(address)))
             {
                 return currentAddress;
             }
 
+            const string sql = "SELECT * FROM sp_save_reunion_address(@userId, @reunionId, @description, @line1, @line2, @city, @state, @zipcode)";
             ParameterDictionary parameters = GetAddressParameters(address, "reunionId", reunionId);
-
-            return (await ExecuteStoredProc("[dbo].[spSaveReunionAddress]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false)).SingleOrDefault();
+            return (await ExecuteStoredProc(sql, parameters).ConfigureAwait(false)).SingleOrDefault();
         }
 
         #region Helper Methods
 
         private static ParameterDictionary GetAddressParameters(Address address, string idColumn, Guid id)
         {
-            return new ParameterDictionary(new string[]
-            {
-                "userId", address.ActionUserId,
-                idColumn, id.ToString(),
+            return new ParameterDictionary(
+                "userId",      address.ActionUserId,
+                idColumn,      id,
                 "description", address.Description,
-                "line1", address.Line1,
-                "line2", address.Line2,
-                "city", address.City,
-                "state", address.State,
-                "zipcode", address.ZipCode
-            });
+                "line1",       address.Line1,
+                "line2",       address.Line2,
+                "city",        address.City,
+                "state",       address.State,
+                "zipcode",     address.ZipCode
+            );
         }
 
         #endregion

--- a/src/FamUnion.Infrastructure/Repository/AttendeeRepository.cs
+++ b/src/FamUnion.Infrastructure/Repository/AttendeeRepository.cs
@@ -1,4 +1,4 @@
-﻿using FamUnion.Core.Interface.Repository;
+using FamUnion.Core.Interface.Repository;
 using FamUnion.Core.Model;
 using FamUnion.Core.Request;
 using FamUnion.Core.Utility;
@@ -14,41 +14,38 @@ namespace FamUnion.Infrastructure.Repository
         public AttendeeRepository(string connection)
             : base(connection)
         {
-
         }
 
         public async Task<IEnumerable<AttendeeInvite>> GetAttendeesByReunion(Guid reunionId)
         {
-            ParameterDictionary parameters = ParameterDictionary.Single("reunionId", reunionId);
-            return await ExecuteStoredProc("[dbo].[spGetInvitesByReunionId]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false);
+            const string sql = "SELECT * FROM sp_get_invites_by_reunion_id(@reunionId)";
+            return await ExecuteStoredProc(sql, ParameterDictionary.Single("reunionId", reunionId))
+                .ConfigureAwait(false);
         }
 
         public async Task AddAttendees(BulkAttendeeRequest request)
         {
+            const string sql = "SELECT sp_create_invites(@invites, @userId)";
             ParameterDictionary parameters = ParameterDictionary.Single("invites", TvpHelper.MapInvites(request.InviteRequests));
             parameters.AddParameter("userId", request.UserId);
-
-            await ExecuteStoredProc("[dbo].[spCreateInvites]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false);
+            await ExecuteNonQueryProc(sql, parameters).ConfigureAwait(false);
         }
 
         public async Task<AttendeeInvite> GetInviteAsync(InviteInfo inviteInfo)
         {
-            ParameterDictionary parameters = ParameterDictionary.Single("inviteId", inviteInfo.InviteId);
-
-            return (await ExecuteStoredProc("[dbo].[spGetInviteById]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false)).FirstOrDefault();
+            const string sql = "SELECT * FROM sp_get_invite_by_id(@inviteId)";
+            return (await ExecuteStoredProc(sql, ParameterDictionary.Single("inviteId", inviteInfo.InviteId))
+                .ConfigureAwait(false)).FirstOrDefault();
         }
 
         public async Task AttendeeResponseAsync(Guid inviteId, Constants.AttendeeResponseStatus status)
         {
-            ParameterDictionary parameters = new ParameterDictionary();
-            parameters.AddParameter("inviteId", inviteId);
-            parameters.AddParameter("status", (int)status);
-
-            await ExecuteStoredProc("[dbo].[spUpdateStatus]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false);
+            const string sql = "SELECT sp_update_invite_status(@inviteId, @status)";
+            ParameterDictionary parameters = new ParameterDictionary(
+                "inviteId", inviteId,
+                "status",   (int)status
+            );
+            await ExecuteNonQueryProc(sql, parameters).ConfigureAwait(false);
         }
     }
 }

--- a/src/FamUnion.Infrastructure/Repository/EventRepository.cs
+++ b/src/FamUnion.Infrastructure/Repository/EventRepository.cs
@@ -1,4 +1,4 @@
-﻿using FamUnion.Core.Interface;
+using FamUnion.Core.Interface;
 using FamUnion.Core.Model;
 using FamUnion.Core.Request;
 using FamUnion.Core.Utility;
@@ -14,48 +14,47 @@ namespace FamUnion.Infrastructure.Repository
         public EventRepository(string connection)
             : base(connection)
         {
-
         }
 
         public async Task<Event> GetEventAsync(Guid eventId)
         {
-            ParameterDictionary parameters = ParameterDictionary.Single("id", eventId.ToString());
-            return (await ExecuteStoredProc("[dbo].[spGetEventById]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false)).SingleOrDefault();
+            const string sql = "SELECT * FROM sp_get_event_by_id(@id)";
+            return (await ExecuteStoredProc(sql, ParameterDictionary.Single("id", eventId))
+                .ConfigureAwait(false)).SingleOrDefault();
         }
 
         public async Task<IEnumerable<Event>> GetEventsByReunionIdAsync(Guid reunionId)
         {
-            ParameterDictionary parameters = ParameterDictionary.Single("reunionId", reunionId.ToString());
-            return await ExecuteStoredProc("[dbo].[spGetEventsByReunionId]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false);
+            const string sql = "SELECT * FROM sp_get_events_by_reunion_id(@reunionId)";
+            return await ExecuteStoredProc(sql, ParameterDictionary.Single("reunionId", reunionId))
+                .ConfigureAwait(false);
         }
 
         public async Task<Event> SaveEventAsync(Event @event)
         {
-            ParameterDictionary parameters = new ParameterDictionary(new string[] {
-                "userId", @event.ActionUserId,
-                "id", @event.Id.GetDbGuidString(),
-                "reunionId", @event.ReunionId.ToString(),
-                "name", @event.Name,
-                "details", @event.Details,
-                "startTime", @event.StartTime.ToString(),
-                "endTime", @event.EndTime.ToString()
-            });
+            const string sql = "SELECT * FROM sp_save_event(@userId, @id, @reunionId, @name, @details, @startTime, @endTime, @attireType)";
+            ParameterDictionary parameters = new ParameterDictionary(
+                "userId",      @event.ActionUserId,
+                "id",          @event.Id ?? Guid.NewGuid(),
+                "reunionId",   @event.ReunionId,
+                "name",        @event.Name,
+                "details",     @event.Details,
+                "startTime",   @event.StartTime.UtcDateTime,
+                "endTime",     @event.EndTime?.UtcDateTime,
+                "attireType",  (int)@event.AttireType
+            );
 
-            return (await ExecuteStoredProc("[dbo].[spSaveEvent]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false)).SingleOrDefault();
+            return (await ExecuteStoredProc(sql, parameters).ConfigureAwait(false)).SingleOrDefault();
         }
 
         public async Task CancelEventAsync(CancelRequest request)
         {
-            ParameterDictionary parameters = new ParameterDictionary(new string[]
-            {
-                "userId", request.UserId,
-                "eventId", request.EntityId.ToString()
-            });
-
-            await ExecuteStoredProc("[dbo].[spCancelEventById]", parameters).ConfigureAwait(continueOnCapturedContext: false);
+            const string sql = "SELECT sp_cancel_event_by_id(@userId, @eventId)";
+            ParameterDictionary parameters = new ParameterDictionary(
+                "userId",  request.UserId,
+                "eventId", request.EntityId
+            );
+            await ExecuteNonQueryProc(sql, parameters).ConfigureAwait(false);
         }
     }
 }

--- a/src/FamUnion.Infrastructure/Repository/ReunionRepository.cs
+++ b/src/FamUnion.Infrastructure/Repository/ReunionRepository.cs
@@ -1,4 +1,4 @@
-﻿using FamUnion.Core.Interface;
+using FamUnion.Core.Interface;
 using FamUnion.Core.Model;
 using FamUnion.Core.Request;
 using FamUnion.Core.Utility;
@@ -12,81 +12,76 @@ namespace FamUnion.Infrastructure.Repository
 {
     public class ReunionRepository : DbAccess<Reunion>, IReunionRepository
     {
-        public ReunionRepository(string connection) 
+        public ReunionRepository(string connection)
             : base(connection)
         {
-
         }
 
         public async Task<Reunion> GetReunionAsync(Guid id)
         {
-            ParameterDictionary parameters = ParameterDictionary.Single("id", id.ToString());
-            return (await ExecuteStoredProc("[dbo].[spGetReunionById]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false)).SingleOrDefault();
+            const string sql = "SELECT * FROM sp_get_reunion_by_id(@id)";
+            return (await ExecuteStoredProc(sql, ParameterDictionary.Single("id", id))
+                .ConfigureAwait(false)).SingleOrDefault();
         }
 
         public async Task<IEnumerable<Reunion>> GetReunionsAsync()
         {
-            return await ExecuteStoredProc("[dbo].[spGetReunions]", ParameterDictionary.Empty)
-                .ConfigureAwait(continueOnCapturedContext: false);
+            return await ExecuteStoredProc("SELECT * FROM sp_get_reunions()")
+                .ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<Reunion>> GetManageReunionsAsync(string userId)
         {
-            return await ExecuteStoredProc("[dbo].[spGetManageReunions]", ParameterDictionary.Single("userId", userId))
-                .ConfigureAwait(continueOnCapturedContext: false);
+            const string sql = "SELECT * FROM sp_get_manage_reunions(@userId)";
+            return await ExecuteStoredProc(sql, ParameterDictionary.Single("userId", userId))
+                .ConfigureAwait(false);
         }
 
         public async Task<Reunion> SaveReunionAsync(Reunion reunion)
         {
-            if(!reunion.IsValid())
+            if (!reunion.IsValid())
             {
                 throw new Exception($"Reunion is not valid|{JsonConvert.SerializeObject(reunion)}");
             }
 
-            ParameterDictionary parameters = new ParameterDictionary(new string[] {
-                "id", reunion.Id.GetDbGuidString(),
-                "userId", reunion.ActionUserId,
-                "name", reunion.Name,
+            const string sql = "SELECT * FROM sp_save_reunion(@id, @userId, @name, @description, @startDate, @endDate)";
+            ParameterDictionary parameters = new ParameterDictionary(
+                "id",          reunion.Id ?? Guid.NewGuid(),
+                "userId",      reunion.ActionUserId,
+                "name",        reunion.Name,
                 "description", reunion.Description,
-                "startDate", reunion.StartDate.ToString(),
-                "endDate", reunion.EndDate.ToString()
-            });
+                "startDate",   reunion.StartDate,
+                "endDate",     reunion.EndDate
+            );
 
-            return (await ExecuteStoredProc("[dbo].[spSaveReunion]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false)).SingleOrDefault();
+            return (await ExecuteStoredProc(sql, parameters).ConfigureAwait(false)).SingleOrDefault();
         }
 
         public async Task CancelReunionAsync(CancelRequest request)
         {
-            ParameterDictionary parameters = ParameterDictionary.Single("reunionId", request.EntityId);
-
-            _ = await ExecuteStoredProc("[dbo].[spDeleteReunionById]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false);
+            const string sql = "SELECT sp_delete_reunion_by_id(@reunionId)";
+            await ExecuteNonQueryProc(sql, ParameterDictionary.Single("reunionId", request.EntityId))
+                .ConfigureAwait(false);
         }
 
         public async Task AddReunionOrganizer(Guid reunionId, string email)
         {
-            ParameterDictionary parameters = new ParameterDictionary(new string[]
-            {
-                "reunionId", reunionId.ToString(),
-                "email", email
-            });
-
-            _ = await ExecuteStoredProc("[dbo].[spAddReunionOrganizer]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false);
+            const string sql = "SELECT sp_add_reunion_organizer(@reunionId, @email)";
+            ParameterDictionary parameters = new ParameterDictionary(
+                "reunionId", reunionId,
+                "email",     email
+            );
+            await ExecuteNonQueryProc(sql, parameters).ConfigureAwait(false);
         }
 
         public async Task RemoveReunionOrganizer(Guid reunionId, string email)
         {
-            ParameterDictionary parameters = new ParameterDictionary(new string[]
-            {
-                "reunionId", reunionId.ToString(),
-                "email", email
-            });
-
-            _ = await ExecuteStoredProc("[dbo].[spRemoveReunionOrganizer]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false);
+            const string sql = "SELECT sp_remove_reunion_organizer(@reunionId, @email)";
+            ParameterDictionary parameters = new ParameterDictionary(
+                "reunionId", reunionId,
+                "email",     email
+            );
+            await ExecuteNonQueryProc(sql, parameters).ConfigureAwait(false);
         }
     }
 }

--- a/src/FamUnion.Infrastructure/Repository/UserAccessRepository.cs
+++ b/src/FamUnion.Infrastructure/Repository/UserAccessRepository.cs
@@ -1,4 +1,4 @@
-﻿using FamUnion.Core.Interface.Repository;
+using FamUnion.Core.Interface.Repository;
 using FamUnion.Core.Utility;
 using System;
 using System.Linq;
@@ -11,35 +11,28 @@ namespace FamUnion.Infrastructure.Repository
         public UserAccessRepository(string connection)
             : base(connection)
         {
-
         }
 
         public async Task<bool> HasReadAccessToEntity(string userId, Constants.EntityType type, Guid id)
         {
-            ParameterDictionary parameters = new ParameterDictionary(new string[]
-            {
-                "userId", userId,
-                "entityType", ((int)type).ToString(),
-                "entityId", id.ToString()
-            });
-
-            var result = (await ExecuteStoredProc("[dbo].[spUserHasReadAccessToEntity]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false)).FirstOrDefault();
-            return result;
+            const string sql = "SELECT result FROM sp_user_has_read_access_to_entity(@userId, @entityType, @entityId)";
+            ParameterDictionary parameters = new ParameterDictionary(
+                "userId",     userId,
+                "entityType", (int)type,
+                "entityId",   id
+            );
+            return (await ExecuteStoredProc(sql, parameters).ConfigureAwait(false)).FirstOrDefault();
         }
 
         public async Task<bool> HasWriteAccessToEntity(string userId, Constants.EntityType type, Guid id)
         {
-            ParameterDictionary parameters = new ParameterDictionary(new string[]
-            {
-                "userId", userId,
-                "entityType", ((int)type).ToString(),
-                "entityId", id.ToString()
-            });
-
-            var result = (await ExecuteStoredProc("[dbo].[spUserHasWriteAccessToEntity]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false)).FirstOrDefault();
-            return result;
+            const string sql = "SELECT result FROM sp_user_has_write_access_to_entity(@userId, @entityType, @entityId)";
+            ParameterDictionary parameters = new ParameterDictionary(
+                "userId",     userId,
+                "entityType", (int)type,
+                "entityId",   id
+            );
+            return (await ExecuteStoredProc(sql, parameters).ConfigureAwait(false)).FirstOrDefault();
         }
     }
 }

--- a/src/FamUnion.Infrastructure/Repository/UserRepository.cs
+++ b/src/FamUnion.Infrastructure/Repository/UserRepository.cs
@@ -1,4 +1,4 @@
-﻿using FamUnion.Core.Interface;
+using FamUnion.Core.Interface;
 using FamUnion.Core.Model;
 using FamUnion.Core.Utility;
 using System;
@@ -13,54 +13,52 @@ namespace FamUnion.Infrastructure.Repository
         public UserRepository(string connection)
             : base(connection)
         {
-
         }
 
         public async Task<bool> ValidateUserIdAsync(string userId)
         {
-            return (await GetUserByIdAsync(userId)
-                .ConfigureAwait(continueOnCapturedContext: false)) != null;
+            return (await GetUserByIdAsync(userId).ConfigureAwait(false)) != null;
         }
 
         public async Task<bool> ValidateEmailAsync(string email)
         {
-            return (await GetUserByEmailAsync(email)
-                .ConfigureAwait(continueOnCapturedContext: false)) != null;
+            return (await GetUserByEmailAsync(email).ConfigureAwait(false)) != null;
         }
 
         public async Task<User> GetUserByIdAsync(string userId)
         {
-            return (await ExecuteStoredProc("[dbo].[spGetUserById]", ParameterDictionary.Single("userId", userId))
-                .ConfigureAwait(continueOnCapturedContext: false)).FirstOrDefault();
+            const string sql = "SELECT * FROM sp_get_user_by_id(@userId)";
+            return (await ExecuteStoredProc(sql, ParameterDictionary.Single("userId", userId))
+                .ConfigureAwait(false)).FirstOrDefault();
         }
 
         public async Task<User> GetUserByEmailAsync(string email)
         {
-            return (await ExecuteStoredProc("[dbo].[spGetUserByEmail]", ParameterDictionary.Single("email", email))
-                .ConfigureAwait(continueOnCapturedContext: false)).FirstOrDefault();
+            const string sql = "SELECT * FROM sp_get_user_by_email(@email)";
+            return (await ExecuteStoredProc(sql, ParameterDictionary.Single("email", email))
+                .ConfigureAwait(false)).FirstOrDefault();
         }
 
         public async Task<User> SaveUserAsync(User user)
         {
-            ParameterDictionary parameters = new ParameterDictionary(new string[] {
-                "id", user.Id.GetDbGuidString(),
-                "userId", user.UserId,
-                "email", user.Email,
+            const string sql = "SELECT * FROM sp_save_user(@id, @userId, @email, @firstName, @lastName, @authType)";
+            ParameterDictionary parameters = new ParameterDictionary(
+                "id",        user.Id ?? Guid.NewGuid(),
+                "userId",    user.UserId,
+                "email",     user.Email,
                 "firstName", user.FirstName,
-                "lastName", user.LastName,
-                "authType", ((int)user.AuthType).ToString()
-            });
+                "lastName",  user.LastName,
+                "authType",  (int)user.AuthType
+            );
 
-            return (await ExecuteStoredProc("[dbo].[spSaveUser]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false)).SingleOrDefault();
+            return (await ExecuteStoredProc(sql, parameters).ConfigureAwait(false)).SingleOrDefault();
         }
 
         public async Task<IEnumerable<User>> GetReunionOrganizers(Guid reunionId)
         {
-            ParameterDictionary parameters = ParameterDictionary.Single("reunionId", reunionId);
-
-            return await ExecuteStoredProc("[dbo].[spGetOrganizersByReunionId]", parameters)
-                .ConfigureAwait(continueOnCapturedContext: false);
+            const string sql = "SELECT * FROM sp_get_organizers_by_reunion_id(@reunionId)";
+            return await ExecuteStoredProc(sql, ParameterDictionary.Single("reunionId", reunionId))
+                .ConfigureAwait(false);
         }
     }
 }

--- a/src/FamUnion.Infrastructure/TvpHelper.cs
+++ b/src/FamUnion.Infrastructure/TvpHelper.cs
@@ -1,31 +1,21 @@
-﻿using Dapper;
 using FamUnion.Core.Request;
-using System;
+using Newtonsoft.Json;
 using System.Collections.Generic;
-using System.Data;
-using System.Text;
+using System.Linq;
 
 namespace FamUnion.Infrastructure
 {
     public static class TvpHelper
     {
-        public static SqlMapper.ICustomQueryParameter MapInvites(IEnumerable<InviteRequest> requests)
+        public static string MapInvites(IEnumerable<InviteRequest> requests)
         {
-            DataTable dt = new DataTable();
-            dt.Columns.Add("ReunionId", typeof(Guid));
-            dt.Columns.Add("Email", typeof(string));
-            dt.Columns.Add("Name", typeof(string));
-
-            foreach(var request in requests)
+            var items = requests.Select(r => new
             {
-                DataRow row = dt.NewRow();
-                row["ReunionId"] = request.ReunionId;
-                row["Email"] = request.Email;
-                row["Name"] = request.Name;
-                dt.Rows.Add(row);
-            }
-
-            return dt.AsTableValuedParameter("[dbo].[udfInviteType]");
+                reunion_id = r.ReunionId,
+                email      = r.Email,
+                name       = r.Name
+            });
+            return JsonConvert.SerializeObject(items);
         }
     }
 }

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -4,9 +4,9 @@ services:
   postgres:
     image: postgres:17
     environment:
-      POSTGRES_DB: famunion
-      POSTGRES_USER: famunion
-      POSTGRES_PASSWORD: famunion
+      POSTGRES_DB: ${POSTGRES_DB:-famunion}
+      POSTGRES_USER: ${POSTGRES_USER:-famunion}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
     ports:
       - "5432:5432"
     volumes:
@@ -20,7 +20,7 @@ services:
     depends_on:
       - postgres
     environment:
-      - ConnectionStrings__FamUnionDb=Host=postgres;Port=5432;Database=famunion;Username=famunion;Password=famunion
+      - ConnectionStrings__FamUnionDb=Host=postgres;Port=5432;Database=${POSTGRES_DB:-famunion};Username=${POSTGRES_USER:-famunion};Password=${POSTGRES_PASSWORD}
 
   famunion.webauth:
     image: ${DOCKER_REGISTRY-}famunionwebauth
@@ -30,7 +30,7 @@ services:
     depends_on:
       - postgres
     environment:
-      - ConnectionStrings__FamUnionDb=Host=postgres;Port=5432;Database=famunion;Username=famunion;Password=famunion
+      - ConnectionStrings__FamUnionDb=Host=postgres;Port=5432;Database=${POSTGRES_DB:-famunion};Username=${POSTGRES_USER:-famunion};Password=${POSTGRES_PASSWORD}
 
 volumes:
   postgres_data:

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       dockerfile: FamUnion.Api/Dockerfile
     depends_on:
       - postgres
+    environment:
+      - ConnectionStrings__FamUnionDb=Host=postgres;Port=5432;Database=famunion;Username=famunion;Password=famunion
 
   famunion.webauth:
     image: ${DOCKER_REGISTRY-}famunionwebauth
@@ -27,6 +29,8 @@ services:
       dockerfile: FamUnion.WebAuth/Dockerfile
     depends_on:
       - postgres
+    environment:
+      - ConnectionStrings__FamUnionDb=Host=postgres;Port=5432;Database=famunion;Username=famunion;Password=famunion
 
 volumes:
   postgres_data:

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-famunion}
       POSTGRES_USER: ${POSTGRES_USER:-famunion}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
       - "5432:5432"
     volumes:

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,14 +1,32 @@
 version: '3.4'
 
 services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_DB: famunion
+      POSTGRES_USER: famunion
+      POSTGRES_PASSWORD: famunion
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
   famunion.api:
     image: ${DOCKER_REGISTRY-}famunionapi
     build:
       context: .
       dockerfile: FamUnion.Api/Dockerfile
+    depends_on:
+      - postgres
 
   famunion.webauth:
     image: ${DOCKER_REGISTRY-}famunionwebauth
     build:
       context: .
       dockerfile: FamUnion.WebAuth/Dockerfile
+    depends_on:
+      - postgres
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary

- **SQL migrations** (`src/FamUnion.Db/Postgres/`): three Flyway-style scripts replace the SQL Server SSDT project — `V1__tables.sql` (7 tables), `V2__functions.sql` (27 PL/pgSQL functions), `V3__seed.sql` (entity_type seed data)
- **NuGet packages**: `Microsoft.Data.SqlClient` → `Npgsql 9.0.3`; `AspNetCore.HealthChecks.SqlServer` → `AspNetCore.HealthChecks.NpgSql 9.0.0`
- **Infrastructure rewrite**: `DbAccess.cs` uses `NpgsqlConnection` + `CommandType.Text`; all 6 repositories updated with PostgreSQL snake_case function names; `TvpHelper` replaces SQL Server TVP with JSON string for the `sp_create_invites` JSONB parameter; `ParameterDictionary` removes `SqlParameter` dependency
- **Startup/config**: `Dapper.DefaultTypeMap.MatchNamesWithUnderscores = true` maps `start_date` → `StartDate` etc.; health check swapped to `AddNpgSql`; `appsettings.json` updated to a PostgreSQL connection string; `docker-compose.yml` adds a `postgres:17` service with a named volume

## Key conversion notes

| SQL Server | PostgreSQL |
|---|---|
| `UNIQUEIDENTIFIER` / `NEWID()` | `UUID` / `gen_random_uuid()` |
| `NVARCHAR` | `VARCHAR` |
| `BIT` | `BOOLEAN` |
| `DATETIME` | `TIMESTAMP` |
| `SYSDATETIME()` / `SUSER_SNAME()` | `NOW()` / `CURRENT_USER` |
| `ISNULL` | `COALESCE` |
| `MERGE … WHEN NOT MATCHED` | `INSERT … ON CONFLICT DO UPDATE/NOTHING` |
| `(NOLOCK)` hints | removed |
| `[dbo].[User]` / `[dbo].[Event]` | `app_user` / `events` (reserved word avoidance) |
| TVP `udfInviteType` | `TEXT` parameter parsed as `JSONB` inside function |
| `CommandType.StoredProcedure` | `CommandType.Text` + `SELECT * FROM func(…)` |

## Test plan

- [ ] Run `V1__tables.sql`, `V2__functions.sql`, `V3__seed.sql` against a local PostgreSQL 17 instance and confirm all objects are created without error
- [ ] Update `appsettings.Development.json` with a real connection string and start the API; verify `/health` returns 200
- [ ] Exercise each endpoint via Swagger UI (`/swagger`) or Postman: create reunion, save event, add attendees (JSON invite list), organizer add/remove, cancel reunion/event
- [ ] Confirm `docker-compose up` brings up `postgres` + `famunion.api` together and the API can reach the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ffUqiLWXrsEQxA6pqDJhg

---
_Generated by [Claude Code](https://claude.ai/code/session_011ffUqiLWXrsEQxA6pqDJhg)_